### PR TITLE
Feature/slack api

### DIFF
--- a/com.domain_expansion.integrity.slack/build.gradle
+++ b/com.domain_expansion.integrity.slack/build.gradle
@@ -31,8 +31,14 @@ dependencies {
     // ksuid
     implementation 'com.github.ksuid:ksuid:1.1.2'
 
+    // feign client
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     // 모니터링
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 
     // spring data
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -44,16 +50,25 @@ dependencies {
     // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // eureka
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     // postgresql
     runtimeOnly 'org.postgresql:postgresql'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/SlackApplication.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/SlackApplication.java
@@ -2,12 +2,14 @@ package com.domain_expansion.integrity.slack;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class SlackApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SlackApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(SlackApplication.class, args);
+    }
 
 }

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/SlackServiceImpl.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/SlackServiceImpl.java
@@ -1,8 +1,15 @@
 package com.domain_expansion.integrity.slack.application;
 
+import com.domain_expansion.integrity.slack.application.client.UserClient;
+import com.domain_expansion.integrity.slack.application.client.response.UserResponseDto;
+import com.domain_expansion.integrity.slack.common.exception.SlackException;
+import com.domain_expansion.integrity.slack.common.message.ExceptionMessage;
+import com.domain_expansion.integrity.slack.common.response.SuccessResponse;
 import com.domain_expansion.integrity.slack.domain.mapper.SlackMapper;
 import com.domain_expansion.integrity.slack.domain.model.Slack;
 import com.domain_expansion.integrity.slack.domain.repository.SlackRepository;
+import com.domain_expansion.integrity.slack.domain.webclient.SlackClient;
+import com.domain_expansion.integrity.slack.domain.webclient.SlackRequestDto;
 import com.domain_expansion.integrity.slack.presentation.request.SlackCreateRequestDto;
 import com.domain_expansion.integrity.slack.presentation.response.SlackResponseDto;
 import com.github.ksuid.Ksuid;
@@ -18,15 +25,25 @@ public class SlackServiceImpl implements SlackService {
     private final SlackRepository slackRepository;
     private final SlackMapper slackMapper;
 
+    private final SlackClient slackClient;
+    private final UserClient userClient;
+
     /**
      * 슬랙 메세지 생성
      */
     @Override
     public SlackResponseDto createSlackMessage(SlackCreateRequestDto requestDto) {
 
-        // TODO: 유저 정보 FeignClient로 전달받는다
+        SuccessResponse<UserResponseDto> userInfoWithResponse = userClient.findUserById(
+            requestDto.receivedId());
 
-        // TODO: 슬랙 전달
+        String slackId = userInfoWithResponse.data().slackId();
+
+        try {
+            slackClient.sendSlackMessage(slackId, new SlackRequestDto(requestDto.message()));
+        } catch (Exception e) {
+            throw new SlackException(ExceptionMessage.AUTHORIZATION);
+        }
 
         String ksUid = Ksuid.newKsuid().toString();
 
@@ -38,7 +55,9 @@ public class SlackServiceImpl implements SlackService {
 
     @Override
     public SlackResponseDto findSlackById(String slackId) {
-        return null;
+        Slack slack = slackRepository.findById(slackId)
+            .orElseThrow(() -> new SlackException(ExceptionMessage.SLACK_NOT_FOUND));
+        return SlackResponseDto.from(slack);
     }
 
 

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/client/UserClient.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/client/UserClient.java
@@ -1,0 +1,17 @@
+package com.domain_expansion.integrity.slack.application.client;
+
+import com.domain_expansion.integrity.slack.application.client.response.UserResponseDto;
+import com.domain_expansion.integrity.slack.common.response.SuccessResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service")
+public interface UserClient {
+
+    @GetMapping(value = "/users/{id}")
+    SuccessResponse<UserResponseDto> findUserById(
+        @PathVariable("id") Long id
+    );
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/client/UserRole.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/client/UserRole.java
@@ -1,0 +1,19 @@
+package com.domain_expansion.integrity.slack.application.client;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    MASTER("ROLE_MASTER"),
+    HUB_MANAGER("ROLE_HUB_MANAGER"),
+    HUB_COMPANY("ROLE_HUB_COMPANY"),
+    HUB_DELIVERY_MAN("ROLE_HUB_DELIVERY_MAN"),
+    COMPANY_DELIVERY_MAN("ROLE_COMPANY_DELIVERY_MAN"),
+    ;
+
+    private final String authority;
+}
+

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/client/response/UserResponseDto.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/application/client/response/UserResponseDto.java
@@ -1,0 +1,13 @@
+package com.domain_expansion.integrity.slack.application.client.response;
+
+import com.domain_expansion.integrity.slack.application.client.UserRole;
+
+public record UserResponseDto(
+    Long userId,
+    String username,
+    UserRole role,
+    String phoneNumber,
+    String slackId
+) {
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/EventSerializer.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/EventSerializer.java
@@ -1,0 +1,31 @@
+package com.domain_expansion.integrity.slack.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EventSerializer {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 직렬화 (객체 -> JSON 문자열)
+    public static <T> String serialize(T object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize object: {}", object, e);
+            throw new RuntimeException("Serialization error", e);
+        }
+    }
+
+    // 역직렬화 (JSON 문자열 -> 객체)
+    public static <T> T deserialize(String json, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize JSON: {}", json, e);
+            throw new RuntimeException("Deserialization error", e);
+        }
+    }
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/entity/BaseDateEntity.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/entity/BaseDateEntity.java
@@ -22,7 +22,7 @@ public abstract class BaseDateEntity {
 
     @Column(name = "created_by", updatable = false)
     @CreatedBy
-    protected String createdUser;
+    protected Long createdUser;
 
     @Column(name = "updated_at")
     @LastModifiedDate
@@ -30,13 +30,13 @@ public abstract class BaseDateEntity {
 
     @Column(name = "updated_by")
     @LastModifiedBy
-    protected String updatedUser;
+    protected Long updatedUser;
 
     @Column(name = "deleted_at")
     protected LocalDateTime deletedAt;
 
     @Column(name = "deleted_by")
-    protected String deletedUser;
+    protected Long deletedUser;
 
     public void deleteEntity() {
         this.deletedAt = LocalDateTime.now();

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/exception/CustomFeignErrorDecoder.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/exception/CustomFeignErrorDecoder.java
@@ -1,0 +1,34 @@
+package com.domain_expansion.integrity.slack.common.exception;
+
+import com.domain_expansion.integrity.slack.common.message.ExceptionMessage;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+public class CustomFeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder defaultErrorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        HttpStatus status = HttpStatus.valueOf(response.status());
+        System.out.println(methodKey);
+        switch (status) {
+            case BAD_REQUEST:
+                return new SlackException(ExceptionMessage.INVALID_INPUT);
+            case NOT_FOUND:
+                log.error("에러 ? : " + response.body());
+                return new SlackException(ExceptionMessage.USER_NOT_FOUND);
+            case INTERNAL_SERVER_ERROR: // todo: 이 부분 외부 노출 고민
+                log.error("에러 ? : " + response.body());
+                return new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "서버 오류가 발생했습니다.");
+            default:
+                return defaultErrorDecoder.decode(methodKey, response);
+        }
+    }
+}
+

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/exception/KafkaErrorHandler.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/exception/KafkaErrorHandler.java
@@ -1,0 +1,26 @@
+package com.domain_expansion.integrity.slack.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class KafkaErrorHandler implements CommonErrorHandler {
+
+    // 컨슈머에서 에러 발생시 처리를 한다.
+    @Override
+    public boolean handleOne(
+        Exception thrownException,
+        ConsumerRecord<?, ?> record,
+        Consumer<?, ?> consumer,
+        MessageListenerContainer container) {
+
+        log.error("Error log in kafka listener message: {}", record.value());
+        return true;
+    }
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/jwt/JwtUtils.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/jwt/JwtUtils.java
@@ -1,0 +1,57 @@
+package com.domain_expansion.integrity.slack.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtils {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    public static final String AUTHORIZATION_KEY = "auth";
+
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String extractToken(HttpServletRequest request) {
+        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(7);
+        }
+
+        return null;
+    }
+
+    public boolean checkValidJwtToken(String jwtToken) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(jwtToken);
+            return true;
+        } catch (Exception e) {
+            log.error("에러 원인 : {} 에러 설명 : {}", e.getCause(), e.getMessage());
+        }
+        return false;
+    }
+
+    public Claims getBodyFromJwt(String jwtToken) {
+        return Jwts.parser().verifyWith(key).build().parseSignedClaims(jwtToken).getPayload();
+    }
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/message/ExceptionMessage.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/message/ExceptionMessage.java
@@ -8,8 +8,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ExceptionMessage {
     // TODO: slack 예외 처리 메시지
-    ;
-
+    AUTHORIZATION(HttpStatus.UNAUTHORIZED, "잘못된 인증정보입니다."),
+    SLACK_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "슬랙 전송에 실패하였습니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    SLACK_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 슬랙 아이디입니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 유저입니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/message/SuccessMessage.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/message/SuccessMessage.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
     //TODO: 슬랙 성공 메세지
     SUCCESS_CREATE_SLACK(HttpStatus.CREATED, "슬랙 생성에 성공하였습니다."),
-    SUCCESS_FIND_SLACKLIST(HttpStatus.CREATED, "슬랙 목록 조회에 성공하였습니다."),
+    SUCCESS_FIND_SLACKLIST(HttpStatus.OK, "슬랙 목록 조회에 성공하였습니다."),
+    SUCCESS_FIND_SLACK(HttpStatus.OK, "슬랙 단일 조회에 성공하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/security/UserDetailsImpl.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/security/UserDetailsImpl.java
@@ -1,0 +1,29 @@
+package com.domain_expansion.integrity.slack.common.security;
+
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public record UserDetailsImpl(
+    Long userId,
+    Collection<? extends GrantedAuthority> authorities,
+    String role
+
+) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        throw new UnsupportedOperationException("UserDetailsImpl#Password() not implemented");
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(this.userId);
+    }
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/security/WebSecurityConfig.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/common/security/WebSecurityConfig.java
@@ -1,0 +1,62 @@
+package com.domain_expansion.integrity.slack.common.security;
+
+import com.domain_expansion.integrity.slack.common.jwt.JwtUtils;
+import com.domain_expansion.integrity.slack.presentation.filter.JwtAuthorizationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true)
+@Configuration
+public class WebSecurityConfig {
+
+    private final JwtUtils jwtUtils;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtils);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        http.sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(
+            SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(
+            (auth) ->
+                auth
+                    .requestMatchers(
+                        PathRequest.toStaticResources().atCommonLocations())
+                    .permitAll() // resources 접근 허용 설정
+//                    .requestMatchers(
+//                        "/api/v1/ais/hub-delivery/slack", "/api/v1/ais/company-delivery/slack",
+//                        "/api/v1/ais/company-delivery/sequence"
+//                    ) // 내부 서비스에서 ai 호출
+//                    .permitAll()
+                    .anyRequest()
+                    .authenticated()
+        );
+
+        http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/domain/webclient/SlackClient.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/domain/webclient/SlackClient.java
@@ -1,0 +1,17 @@
+package com.domain_expansion.integrity.slack.domain.webclient;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+@HttpExchange
+public interface SlackClient {
+
+    @PostExchange("/{slackId}")
+    String sendSlackMessage(
+        @PathVariable("slackId") String slackId,
+        @RequestBody SlackRequestDto requestDto
+    );
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/domain/webclient/SlackRequestDto.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/domain/webclient/SlackRequestDto.java
@@ -1,0 +1,8 @@
+package com.domain_expansion.integrity.slack.domain.webclient;
+
+public record SlackRequestDto(
+    String text
+) {
+
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/infrasturcture/config/JpaAuditConfig.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/infrasturcture/config/JpaAuditConfig.java
@@ -1,10 +1,28 @@
 package com.domain_expansion.integrity.slack.infrasturcture.config;
 
+import com.domain_expansion.integrity.slack.common.security.UserDetailsImpl;
+import java.util.Optional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @EnableJpaAuditing
 @Configuration
-public class JpaAuditConfig {
+public class JpaAuditConfig implements AuditorAware<Long> {
+
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated() || authentication.getName()
+            .equals("anonymousUser")) {
+            return Optional.empty();
+        }
+        String userId = ((UserDetailsImpl) authentication.getPrincipal()).getUsername();
+        return Optional.of(Long.parseLong(userId));
+    }
 
 }

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/infrasturcture/config/KafkaConfig.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/infrasturcture/config/KafkaConfig.java
@@ -1,0 +1,52 @@
+package com.domain_expansion.integrity.slack.infrasturcture.config;
+
+import com.domain_expansion.integrity.slack.common.exception.KafkaErrorHandler;
+import java.util.HashMap;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+
+@RequiredArgsConstructor
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    private final KafkaErrorHandler kafkaErrorHandler;
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String serverUrl;
+
+    /**
+     * 카프카 설정
+     */
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        HashMap<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, serverUrl);
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    // 에러 핸들링 추가위한
+    @Bean
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, String>>
+    kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(consumerFactory());
+        factory.setCommonErrorHandler(kafkaErrorHandler);
+
+        return factory;
+    }
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/infrasturcture/config/SlackClientAdapter.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/infrasturcture/config/SlackClientAdapter.java
@@ -1,0 +1,36 @@
+package com.domain_expansion.integrity.slack.infrasturcture.config;
+
+import com.domain_expansion.integrity.slack.domain.webclient.SlackClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Configuration
+public class SlackClientAdapter {
+
+    private String slackUrl;
+
+    public SlackClientAdapter(@Value("${slack.url}") String slackUrl) {
+        this.slackUrl = slackUrl;
+    }
+
+    @Bean
+    SlackClient slackWebClient() {
+        DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory(
+            (slackUrl));
+
+        RestClient restClient = RestClient.builder()
+            .uriBuilderFactory(uriBuilderFactory)
+            .build();
+
+        RestClientAdapter adapter = RestClientAdapter.create(restClient);
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+
+        return factory.createClient(SlackClient.class);
+    }
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/SlackController.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/SlackController.java
@@ -1,8 +1,12 @@
 package com.domain_expansion.integrity.slack.presentation;
 
+import static com.domain_expansion.integrity.slack.common.message.SuccessMessage.SUCCESS_CREATE_SLACK;
+import static com.domain_expansion.integrity.slack.common.message.SuccessMessage.SUCCESS_FIND_SLACK;
+import static com.domain_expansion.integrity.slack.common.message.SuccessMessage.SUCCESS_FIND_SLACKLIST;
+
 import com.domain_expansion.integrity.slack.application.SlackService;
 import com.domain_expansion.integrity.slack.common.aop.DefaultPageSize;
-import com.domain_expansion.integrity.slack.common.message.SuccessMessage;
+import com.domain_expansion.integrity.slack.common.response.CommonResponse;
 import com.domain_expansion.integrity.slack.common.response.SuccessResponse;
 import com.domain_expansion.integrity.slack.presentation.request.SlackCreateRequestDto;
 import com.domain_expansion.integrity.slack.presentation.response.SlackResponseDto;
@@ -10,7 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,38 +34,50 @@ public class SlackController {
      * 슬랙 메세지 생성
      */
     @PostMapping
-    public SuccessResponse<SlackResponseDto> createSlackMessage(
+    public ResponseEntity<? extends CommonResponse> createSlackMessage(
         @RequestBody SlackCreateRequestDto requestDto
     ) {
 
         SlackResponseDto slackInfo = slackService.createSlackMessage(requestDto);
-        return SuccessResponse.of(SuccessMessage.SUCCESS_CREATE_SLACK.getMessage(), slackInfo);
+        return ResponseEntity.status(SUCCESS_CREATE_SLACK.getHttpStatus())
+            .body(SuccessResponse.of(SUCCESS_CREATE_SLACK.getMessage(), slackInfo));
     }
 
     /**
      * slack 메세지 전체 조회
      */
+    @PreAuthorize("hasAnyRole('ROLE_MASTER')")
     @DefaultPageSize
     @GetMapping
-    public SuccessResponse<?> findSlackMessageList(
+    public ResponseEntity<? extends CommonResponse> findSlackMessageList(
         @PageableDefault(value = 10, size = 10, page = 0) Pageable pageable
     ) {
-        
-        //TODO: 관리자 전용
+
         Page<SlackResponseDto> slackList = slackService.findSlackList(pageable);
 
-        return SuccessResponse.of(SuccessMessage.SUCCESS_FIND_SLACKLIST.getMessage(),
-            slackList
+        return ResponseEntity.status(SUCCESS_FIND_SLACKLIST.getHttpStatus()).body(
+            SuccessResponse.of(SUCCESS_FIND_SLACKLIST.getMessage(),
+                slackList
+            )
         );
     }
 
     /**
      * slack 메세지 개별 조회
      */
-    @GetMapping("{id}")
-    public SuccessResponse<?> findSlackMessageById() {
+    @PreAuthorize("hasAnyRole('ROLE_MASTER')")
+    @GetMapping("/{id}")
+    public ResponseEntity<? extends CommonResponse> findSlackMessageById(
+        @PathVariable("id") String id
+    ) {
 
-        return SuccessResponse.of("", null);
+        SlackResponseDto slackById = slackService.findSlackById(id);
+
+        return ResponseEntity.status(SUCCESS_FIND_SLACK.getHttpStatus()).body(
+            SuccessResponse.of(SUCCESS_FIND_SLACK.getMessage(),
+                slackById
+            )
+        );
     }
 
 

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/SlackEndpoint.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/SlackEndpoint.java
@@ -1,0 +1,27 @@
+package com.domain_expansion.integrity.slack.presentation;
+
+import com.domain_expansion.integrity.slack.application.SlackService;
+import com.domain_expansion.integrity.slack.common.EventSerializer;
+import com.domain_expansion.integrity.slack.presentation.events.SlackAiEventDto;
+import com.domain_expansion.integrity.slack.presentation.request.SlackCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SlackEndpoint {
+
+    private final SlackService slackService;
+
+    @KafkaListener(groupId = "ai-slack-group", topics = "ai.slack")
+    public void aiMessageToSlack(String message) {
+        SlackAiEventDto output = EventSerializer.deserialize(message, SlackAiEventDto.class);
+        slackService.createSlackMessage(
+            new SlackCreateRequestDto(output.userId(), output.aiAnswer()));
+
+    }
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/events/SlackAiEventDto.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/events/SlackAiEventDto.java
@@ -1,0 +1,8 @@
+package com.domain_expansion.integrity.slack.presentation.events;
+
+public record SlackAiEventDto(
+    Long userId,
+    String aiAnswer
+) {
+
+}

--- a/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/filter/JwtAuthorizationFilter.java
+++ b/com.domain_expansion.integrity.slack/src/main/java/com/domain_expansion/integrity/slack/presentation/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,76 @@
+package com.domain_expansion.integrity.slack.presentation.filter;
+
+import static com.domain_expansion.integrity.slack.common.message.ExceptionMessage.AUTHORIZATION;
+
+import com.domain_expansion.integrity.slack.common.exception.SlackException;
+import com.domain_expansion.integrity.slack.common.jwt.JwtUtils;
+import com.domain_expansion.integrity.slack.common.security.UserDetailsImpl;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtUtils.extractToken(request);
+
+        if (StringUtils.hasText(tokenValue)) {
+            if (!jwtUtils.checkValidJwtToken(tokenValue)) {
+                throw new SlackException(AUTHORIZATION);
+            }
+
+            Claims info = jwtUtils.getBodyFromJwt(tokenValue);
+
+            try {
+                setAuthentication(Long.valueOf(info.getSubject()),
+                    info.get(JwtUtils.AUTHORIZATION_KEY).toString());
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+    public void setAuthentication(Long userId, String role) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(userId, role);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    private Authentication createAuthentication(Long userId, String role) {
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(role);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return new UsernamePasswordAuthenticationToken(
+            new UserDetailsImpl(userId, authorities, role), null,
+            authorities);
+    }
+}

--- a/com.domain_expansion.integrity.slack/src/main/resources/application.yml
+++ b/com.domain_expansion.integrity.slack/src/main/resources/application.yml
@@ -15,16 +15,28 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
-      format_sql: true
-      show_sql: true
+      hibernate:
+        format_sql: true
+        show_sql: true
   #        database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+  kafka:
+    bootstrap-servers: localhost:9092
+
+
 
 eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}
+
+slack:
+  url: https://hooks.slack.com/services/T07MKQDE5RA/B07M3CY2PQF
 
 server:
   port: 19099

--- a/com.domain_expansion.integrity.slack/src/main/resources/application.yml
+++ b/com.domain_expansion.integrity.slack/src/main/resources/application.yml
@@ -36,7 +36,7 @@ jwt:
     key: ${JWT_SECRET_KEY}
 
 slack:
-  url: https://hooks.slack.com/services/T07MKQDE5RA/B07M3CY2PQF
+  url: ${SLACK_WEBHOOK_URL}
 
 server:
   port: 19099

--- a/com.domain_expansion.integrity.user/src/main/java/com/domain_expansion/integrity/user/presentation/endpoint/UserEndpoint.java
+++ b/com.domain_expansion.integrity.user/src/main/java/com/domain_expansion/integrity/user/presentation/endpoint/UserEndpoint.java
@@ -7,6 +7,8 @@ import com.domain_expansion.integrity.user.presentation.response.UserResponseDto
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
  * MSa 내부용 EndPoint
  */
 @RequiredArgsConstructor
-@RequestMapping("users")
+@RequestMapping("users") //TODO: 추후 version진행
 @RestController
 public class UserEndpoint {
 
@@ -34,6 +36,17 @@ public class UserEndpoint {
 
         UserResponseDto responseDto = userService.findUserByUsernameAndPassword(
             requestDto);
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(SuccessResponse.of("유저 정보 전달", responseDto));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SuccessResponse<UserResponseDto>> findUserById(
+        @PathVariable Long id
+    ) {
+
+        UserResponseDto responseDto = userService.findUserById(id);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(SuccessResponse.of("유저 정보 전달", responseDto));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28 
## 📝작업 내용

> Slack 송신 및 조회 기능 추가

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> Slack 생성을 Controller와 KafkaListner로 나눠져 있습니다. 
> kafka 테스트 해보고 싶으시면 Kafka 쪽으로 호출해주시면 됩니다.

> Schedule로 생성되는 api는 인증이 없을거라 예상하여 일단 인증을 걸지 않았습니다.
> 제가 생각하는 방법 중 하나는 외부 api와 url를 분리하여서 Gateway 이외에는 외부로 노출 안시키는 방법을 생각중입니다. 
> 더 좋은 방법 있으시면 논의 해보면 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
  - Slack 메시지 전송 및 사용자 정보 검색을 위한 새로운 API 엔드포인트 추가.
  - JWT 기반 인증 및 권한 부여를 위한 필터 추가.
  - Kafka 메시지 처리를 위한 새로운 리스너 및 서비스 통합.
  - 사용자 역할 및 응답 DTO 추가로 역할 기반 접근 제어 강화.

- **버그 수정**
  - Slack 메시지 전송 오류에 대한 개선된 예외 처리 및 사용자 피드백 제공.

- **구성 변경**
  - 데이터베이스 스키마 관리 전략을 업데이트로 변경하여 데이터 무결성 유지.
  - Kafka 및 Slack 통합을 위한 새로운 구성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->